### PR TITLE
Added isAlarm method

### DIFF
--- a/DS3232RTC.cpp
+++ b/DS3232RTC.cpp
@@ -280,6 +280,18 @@ bool DS3232RTC::alarm(byte alarmNumber)
 }
 
 /*----------------------------------------------------------------------*
+ * Returns true or false depending on whether the given alarm has been  *
+ * triggered                                                            *
+ *----------------------------------------------------------------------*/
+bool DS3232RTC::isAlarm(byte alarmNumber)
+{
+    uint8_t statusReg, mask;
+    
+    statusReg = readRTC(RTC_STATUS);
+    mask = _BV(A1F) << (alarmNumber - 1);
+    return statusReg & mask;
+}
+/*----------------------------------------------------------------------*
  * Enable or disable the square wave output.                            *
  * Use a value from the SQWAVE_FREQS_t enumeration for the parameter.   *
  *----------------------------------------------------------------------*/

--- a/DS3232RTC.h
+++ b/DS3232RTC.h
@@ -143,6 +143,7 @@ class DS3232RTC
         void setAlarm(ALARM_TYPES_t alarmType, byte minutes, byte hours, byte daydate);
         void alarmInterrupt(byte alarmNumber, bool alarmEnabled);
         bool alarm(byte alarmNumber);
+        bool isAlarm(byte alarmNumber);
         void squareWave(SQWAVE_FREQS_t freq);
         bool oscStopped(bool clearOSF = true);  //defaults to clear the OSF bit if argument not supplied
         int temperature(void);


### PR DESCRIPTION
Added isAlarm as method to only query if an alarm occurred without
automatically resetting the flag.
I needed that because I had a situation where I needed to disable the Interrupt for the pin where the RTC was connected and so missed an alarm.
I think this is a good addition to the functionality. What do you think?