### PR TITLE
Use TimeLib.h, for compatibility with Arduino 1.6.10 (newer avr-libc)

### DIFF
--- a/DS3232RTC.cpp
+++ b/DS3232RTC.cpp
@@ -1,7 +1,7 @@
 /*----------------------------------------------------------------------*
  * DS3232RTC.cpp - Arduino library for the Maxim Integrated DS3232      *
  * Real-Time Clock. This library is intended for use with the Arduino   *
- * Time.h library, http://www.arduino.cc/playground/Code/Time           *
+ * TimeLib.h library, http://www.arduino.cc/playground/Code/Time        *
  *                                                                      *
  * This library is a drop-in replacement for the DS1307RTC.h library    *
  * by Michael Margolis that is supplied with the Arduino Time library   *

--- a/DS3232RTC.h
+++ b/DS3232RTC.h
@@ -1,7 +1,7 @@
 /*----------------------------------------------------------------------*
  * DS3232RTC.h - Arduino library for the Maxim Integrated DS3232        *
  * Real-Time Clock. This library is intended for use with the Arduino   *
- * Time.h library, http://www.arduino.cc/playground/Code/Time           *
+ * TimeLib.h library, http://www.arduino.cc/playground/Code/Time        *
  *                                                                      *
  * This library is a drop-in replacement for the DS1307RTC.h library    *
  * by Michael Margolis that is supplied with the Arduino Time library   *
@@ -37,7 +37,7 @@
 
 #ifndef DS3232RTC_h
 #define DS3232RTC_h
-#include <Time.h>
+#include <TimeLib.h>
 
 #if defined(ARDUINO) && ARDUINO >= 100
 #include <Arduino.h> 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -38,7 +38,7 @@ Similar to the **DS1307RTC** library, the **DS3232RTC** library instantiates an 
 To use the **DS3232RTC** library, the Time and Wire libraries must also be included.  For brevity, these includes are not repeated in the examples below:
 ```c++
 #include <DS3232RTC.h>    //http://github.com/JChristensen/DS3232RTC
-#include <Time.h>         //http://www.arduino.cc/playground/Code/Time
+#include <TimeLib.h>      //http://www.arduino.cc/playground/Code/Time
 #include <Wire.h>         //http://arduino.cc/en/Reference/Wire (included with Arduino IDE)
 ```
 

--- a/examples/SetSerial/SetSerial.ino
+++ b/examples/SetSerial/SetSerial.ino
@@ -34,7 +34,7 @@
  
 #include <DS3232RTC.h>        //http://github.com/JChristensen/DS3232RTC
 #include <Streaming.h>        //http://arduiniana.org/libraries/streaming/
-#include <Time.h>             //http://playground.arduino.cc/Code/Time
+#include <TimeLib.h>          //http://playground.arduino.cc/Code/Time
 #include <Wire.h>             //http://arduino.cc/en/Reference/Wire
 
 void setup(void)
@@ -59,7 +59,7 @@ void loop(void)
     if (Serial.available() >= 12) {
         //note that the tmElements_t Year member is an offset from 1970,
         //but the RTC wants the last two digits of the calendar year.
-        //use the convenience macros from Time.h to do the conversions.
+        //use the convenience macros from TimeLib.h to do the conversions.
         int y = Serial.parseInt();
         if (y >= 100 && y < 1000)
             Serial << F("Error: Year must be two digits or four digits!") << endl;

--- a/examples/TimeRTC/TimeRTC.ino
+++ b/examples/TimeRTC/TimeRTC.ino
@@ -6,7 +6,7 @@
  */
 
 #include <DS3232RTC.h>    //http://github.com/JChristensen/DS3232RTC
-#include <Time.h>         //http://www.arduino.cc/playground/Code/Time  
+#include <TimeLib.h>      //http://www.arduino.cc/playground/Code/Time
 #include <Wire.h>         //http://arduino.cc/en/Reference/Wire (included with Arduino IDE)
 
 void setup(void)

--- a/examples/tiny3232_KnockBang/tiny3232_KnockBang.ino
+++ b/examples/tiny3232_KnockBang/tiny3232_KnockBang.ino
@@ -24,7 +24,7 @@
  *----------------------------------------------------------------------*/ 
 
 #include <DS3232RTC.h>             //http://github.com/JChristensen/DS3232RTC
-#include <Time.h>                  //http://playground.arduino.cc/Code/Time
+#include <TimeLib.h>               //http://playground.arduino.cc/Code/Time
 #include <TinyDebugKnockBang.h>    //http://code.google.com/p/arduino-tiny/
 #include <TinyWireM.h>             //http://playground.arduino.cc/Code/USIi2c
 


### PR DESCRIPTION
Newer versions of the Time library use TimeLib.h.  This has been necessary for some time on 32 bit ARM chips, because the C library has a file named "time.h" which conflicts on Windows and Mac case-insensitive filesystems.  Now Arduino 1.6.10 has an updated C library for AVR which also conflicts.

Here's a recent report of the problem:
http://forum.arduino.cc/index.php?topic=415314.msg2860438#msg2860438

Please apply this simple patch to use TimeLib.h instead of Time.h.
