### PR TITLE
Fixed constants name conflict with DallasTemperature library

### DIFF
--- a/DS3232RTC.cpp
+++ b/DS3232RTC.cpp
@@ -323,8 +323,8 @@ int DS3232RTC::temperature(void)
         byte b[2];
     } rtcTemp;
     
-    rtcTemp.b[0] = readRTC(TEMP_LSB);
-    rtcTemp.b[1] = readRTC(TEMP_MSB);
+    rtcTemp.b[0] = readRTC(RTC_TEMP_LSB);
+    rtcTemp.b[1] = readRTC(RTC_TEMP_MSB);
     return rtcTemp.i / 64;
 }
 

--- a/DS3232RTC.h
+++ b/DS3232RTC.h
@@ -66,8 +66,8 @@
 #define RTC_CONTROL 0x0E
 #define RTC_STATUS 0x0F
 #define RTC_AGING 0x10
-#define TEMP_MSB 0x11
-#define TEMP_LSB 0x12
+#define RTC_TEMP_MSB 0x11
+#define RTC_TEMP_LSB 0x12
 #define SRAM_START_ADDR 0x14    //first SRAM address
 #define SRAM_SIZE 236           //number of bytes of SRAM
 


### PR DESCRIPTION
As reported in #28,  there is a conflict between this library and the DallasTemperature library, since both of them define `TEMP_LSB` and `TEMP_MSB`. For this reason I renamed them:

* `TEMP_LSB` -> `RTC_TEMP_LSB`
* `TEMP_MSB` -> `RTC_TEMP_MSB`