### PR TITLE
Fix header Markdown in README.md

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -74,31 +74,31 @@ Symbolic names used with the setAlarm() method (described below).
 
 ## Methods for setting and reading the time ##
 
-###get(void)
-#####Description
+### get(void)
+##### Description
 Reads the current date and time from the RTC and returns it as a *time_t* value. Returns zero if an I2C error occurs (RTC not present, etc.).
-#####Syntax
+##### Syntax
 `RTC.get();`
-#####Parameters
+##### Parameters
 None.
-#####Returns
+##### Returns
 Current date and time *(time_t)*
-#####Example
+##### Example
 ```c++
 time_t myTime;
 myTime = RTC.get();
 ```
 
-###set(time_t t)
-#####Description
+### set(time_t t)
+##### Description
 Sets the RTC date and time to the given *time_t* value. Clears the oscillator stop flag (OSF) bit in the control/status register. See the `oscStopped()` function and also the DS323x datasheet for more information on the OSF bit.
-#####Syntax
+##### Syntax
 `RTC.set(t);`
-#####Parameters
+##### Parameters
 **t:** The date and time to set the RTC to *(time_t)*
-#####Returns
+##### Returns
 I2C status *(byte)*. Returns zero if successful.
-#####Example
+##### Example
 ```c++
 //this example first sets the system time (maintained by the Time library) to
 //a hard-coded date and time, and then sets the RTC from the system time.
@@ -107,16 +107,16 @@ setTime(23, 31, 30, 13, 2, 2009);   //set the system time to 23h31m30s on 13Feb2
 RTC.set(now());                     //set the RTC from the system time
 ```
 
-###read(tmElements_t &tm)
-#####Description
+### read(tmElements_t &tm)
+##### Description
 Reads the current date and time from the RTC and returns it as a *tmElements_t* structure. See the [Arduino Time library](http://www.arduino.cc/playground/Code/Time) for details on the *tmElements_t* structure.
-#####Syntax
+##### Syntax
 `RTC.read(tm);`
-#####Parameters
+##### Parameters
 **tm:** Address of a *tmElements_t* structure to which the date and time are returned.
-#####Returns
+##### Returns
 I2C status *(byte)*. Returns zero if successful. The date and time read from the RTC are returned to the **tm** parameter.
-#####Example
+##### Example
 ```c++
 tmElements_t tm;
 RTC.read(tm);
@@ -127,16 +127,16 @@ Serial.print(':');
 Serial.println(tm.Second,DEC);
 ```
 
-###write(tmElements_t &tm)
-#####Description
+### write(tmElements_t &tm)
+##### Description
 Sets the RTC to the date and time given by a *tmElements_t* structure. Clears the oscillator stop flag (OSF) bit in the control/status register. See the `oscStopped()` function and also the DS323x datasheet for more information on the OSF bit.
-#####Syntax
+##### Syntax
 `RTC.write(tm);`
-#####Parameters
+##### Parameters
 **tm:** Address of a *tmElements_t* structure used to set the date and time.
-#####Returns
+##### Returns
 I2C status *(byte)*. Returns zero if successful.
-#####Example
+##### Example
 ```c++
 tmElements_t tm;
 tm.Hour = 23;             //set the tm structure to 23h31m30s on 13Feb2009
@@ -151,67 +151,67 @@ RTC.write(tm);            //set the RTC from the tm structure
 ## Methods for reading and writing RTC registers or static RAM (SRAM) for the DS3232 ##
 The DS3232RTC.h file defines symbolic names for the timekeeping, alarm, status and control registers. These can be used for the addr argument in the functions below.
 
-###writeRTC(byte addr, byte *values, byte nBytes)
-#####Description
+### writeRTC(byte addr, byte *values, byte nBytes)
+##### Description
 Write one or more bytes to RTC memory.
-#####Syntax
+##### Syntax
 `RTC.writeRTC(addr, values, nbytes);`
-#####Parameters
+##### Parameters
 **addr:** First SRAM address to write *(byte)*. The valid address range is 0x00-0x12 for DS3231, 0x00-0xFF for DS3232. The general-purpose SRAM for the DS3232 begins at address 0x14. Address is not checked for validity by the library.
 **values:** An array of values to write _(*byte)_  
 **nBytes:** Number of bytes to write *(byte)*. Must be between 1 and 31 (Wire library limitation) but is not checked by the library. 
-#####Returns
+##### Returns
 I2C status *(byte)*. Returns zero if successful.
-#####Example
+##### Example
 ```c++
 //write 1, 2, ..., 8 to the first eight DS3232 SRAM locations
 byte buf[8] = {1, 2, 3, 4, 5, 6, 7, 8};
 RTC.sramWrite(0x14, buf, 8);
 ```
 
-###writeRTC(byte addr, byte value)
-#####Description
+### writeRTC(byte addr, byte value)
+##### Description
 Write a single byte to RTC memory.
-#####Syntax
+##### Syntax
 `RTC.writeRTC(addr, value);`
-#####Parameters
+##### Parameters
 **addr:** SRAM address to write *(byte)*. The valid address range is 0x00-0x12 for DS3231, 0x00-0xFF for DS3232. The general-purpose SRAM for the DS3232 begins at address 0x14. Address is not checked for validity by the library.
 **value:** Value to write _(byte)_  
-#####Returns
+##### Returns
 I2C status *(byte)*. Returns zero if successful.
-#####Example
+##### Example
 ```c++
 RTC.writeRTC(3, 14);   //write the value 14 to SRAM address 3
 ```
 
-###readRTC(byte addr, byte *values, byte nBytes)
-#####Description
+### readRTC(byte addr, byte *values, byte nBytes)
+##### Description
 Read one or more bytes from RTC RAM.
-#####Syntax
+##### Syntax
 `RTC.readRTC(addr, values, nbytes);`
-#####Parameters
+##### Parameters
 **addr:** First SRAM address to read *(byte)*. The valid address range is 0x00-0x12 for DS3231, 0x00-0xFF for DS3232. The general-purpose SRAM for the DS3232 begins at address 0x14. Address is not checked for validity by the library.
 **values:** An array to receive the values read _(*byte)_  
 **nBytes:** Number of bytes to read *(byte)*. Must be between 1 and 32 (Wire library limitation) but is not checked by the library. 
-#####Returns
+##### Returns
 I2C status *(byte)*. Returns zero if successful.
-#####Example
+##### Example
 ```c++
 //read the last eight locations of SRAM into buf
 byte buf[8];
 RTC.sramRead(248, buf, 8);
 ```
 
-###readRTC(byte addr)
-#####Description
+### readRTC(byte addr)
+##### Description
 Reads a single byte from RTC RAM.
-#####Syntax
+##### Syntax
 `RTC.readRTC(addr);`
-#####Parameters
+##### Parameters
 **addr:** SRAM address to read *(byte)*. The valid address range is 0x00-0x12 for DS3231, 0x00-0xFF for DS3232. The general-purpose SRAM for the DS3232 begins at address 0x14. Address is not checked for validity by the library.
-#####Returns
+##### Returns
 Value read from the RTC *(byte)*
-#####Example
+##### Example
 ```c++
 byte val;
 val = RTC.readRTC(3);  //read the value from SRAM location 3
@@ -220,72 +220,72 @@ val = RTC.readRTC(3);  //read the value from SRAM location 3
 ## Alarm methods ##
 The DS3232 and DS3231 have two alarms. Alarm1 can be set to seconds precision; Alarm2 can only be set to minutes precision.
 
-###setAlarm(ALARM_TYPES_t alarmType, byte seconds, byte minutes, byte hours, byte daydate)
-#####Description
+### setAlarm(ALARM_TYPES_t alarmType, byte seconds, byte minutes, byte hours, byte daydate)
+##### Description
 Set an alarm time. Sets the alarm registers only.  To cause the INT pin to be asserted on alarm match, use alarmInterrupt(). This method can set either Alarm 1 or Alarm 2, depending on the value of alarmType (use the ALARM_TYPES_t enumeration above). When setting Alarm 2, the seconds value must be supplied but is ignored, recommend using zero. (Alarm 2 has no seconds register.)
 
-#####Syntax
+##### Syntax
 `RTC.setAlarm(alarmType, seconds, minutes, hours, dayOrDate);`
-#####Parameters
+##### Parameters
 **alarmType:** A value from the ALARM_TYPES_t enumeration, above. *(ALARM_TYPES_t)*  
 **seconds:** The seconds value to set the alarm to. *(byte)*  
 **minutes:** The minutes value to set the alarm to. *(byte)*  
 **hours:** The hours value to set the alarm to. *(byte)*  
 **dayOrDate:** The day of the week or the date of the month. For day of the week, use a value from the Time library timeDayOfWeek_t enumeration, i.e. dowSunday, dowMonday, dowTuesday, dowWednesday, dowThursday, dowFriday, dowSaturday. *(byte)*  
-#####Returns
+##### Returns
 None.
-#####Example
+##### Example
 ```c++
 //Set Alarm1 for 12:34:56 on Sunday
 RTC.setAlarm(ALM1_MATCH_DAY, 56, 34, 12, dowSunday);
 ```
 
-###setAlarm(ALARM_TYPES_t alarmType, byte minutes, byte hours, byte daydate)
-#####Description
+### setAlarm(ALARM_TYPES_t alarmType, byte minutes, byte hours, byte daydate)
+##### Description
 Set an alarm time. Sets the alarm registers only.  To cause the INT pin to be asserted on alarm match, use alarmInterrupt().  This method can set either Alarm 1 or Alarm 2, depending on the value of alarmType (use the ALARM_TYPES_t enumeration above). However, when using this method to set Alarm 1, the seconds value is set to zero. (Alarm 2 has no seconds register.)
 
-#####Syntax
+##### Syntax
 `RTC.setAlarm(alarmType, minutes, hours, dayOrDate);`
-#####Parameters
+##### Parameters
 **alarmType:** A value from the ALARM_TYPES_t enumeration, above. *(ALARM_TYPES_t)*  
 **minutes:** The minutes value to set the alarm to. *(byte)*  
 **hours:** The hours value to set the alarm to. *(byte)*  
 **dayOrDate:** The day of the week or the date of the month. For day of the week, use a value from the Time library timeDayOfWeek_t enumeration, i.e. dowSunday, dowMonday, dowTuesday, dowWednesday, dowThursday, dowFriday, dowSaturday. *(byte)*  
-#####Returns
+##### Returns
 None.
-#####Example
+##### Example
 ```c++
 //Set Alarm2 for 12:34 on the 4th day of the month
 RTC.setAlarm(ALM1_MATCH_DATE, 34, 12, 4);
 ```
 
-###alarmInterrupt(byte alarmNumber, boolean alarmEnabled)
-#####Description
+### alarmInterrupt(byte alarmNumber, boolean alarmEnabled)
+##### Description
 Enable or disable an alarm "interrupt". Note that this "interrupt" causes the RTC's INT pin to be asserted. To use this signal as an actual interrupt to a microcontroller, it will need to be connected properly and programmed in the application firmware.
 on the RTC.   
-#####Syntax
+##### Syntax
 `RTC.alarmInterrupt(alarmNumber, enable);`
-#####Parameters
+##### Parameters
 **alarmNumber:** The number of the alarm to enable or disable, ALARM_1 or ALARM_2 *(byte)*  
 **alarmEnabled:** true or false *(boolean)*  
-#####Returns
+##### Returns
 None.
-#####Example
+##### Example
 ```c++
 RTC.alarmInterrupt(ALARM_1, true);      //assert the INT pin when Alarm1 occurs.
 RTC.alarmInterrupt(ALARM_2, false);     //disable Alarm2
 ```
 
-###alarm(byte alarmNumber)
-#####Description
+### alarm(byte alarmNumber)
+##### Description
 Tests whether an alarm has been triggered. If the alarm was triggered, returns true and resets the alarm flag in the RTC, else returns false.
-#####Syntax
+##### Syntax
 `RTC.alarm(alarmNumber);`
-#####Parameters
+##### Parameters
 **alarmNumber:** The number of the alarm to test, ALARM_1 or ALARM_2 *(byte)*  
-#####Returns
+##### Returns
 Description *(type)*
-#####Example
+##### Example
 ```c++
 if ( RTC.alarm(ALARM_1) ) {		//has Alarm1 triggered?
 	//yes, act on the alarm
@@ -296,48 +296,48 @@ else {
 ```
 
 ## Other methods ##
-###temperature(void)
-#####Description
+### temperature(void)
+##### Description
 Returns the RTC temperature.
-#####Syntax
+##### Syntax
 `RTC.temperature();`
-#####Parameters
+##### Parameters
 None.
-#####Returns
+##### Returns
 RTC temperature as degrees Celsius times four. *(int)*
-#####Example
+##### Example
 ```c++
 int t = RTC.temperature();
 float celsius = t / 4.0;
 float fahrenheit = celsius * 9.0 / 5.0 + 32.0;
 ```
 
-###squareWave(SQWAVE_FREQS_t freq)
-#####Description
+### squareWave(SQWAVE_FREQS_t freq)
+##### Description
 Enables or disables the square wave output.
-#####Syntax
+##### Syntax
 `RTC.squareWave(freq);`
-#####Parameters
+##### Parameters
 **freq:** a value from the SQWAVE_FREQS_t enumeration above. *(SQWAVE_FREQS_t)*  
-#####Returns
+##### Returns
 None.
-#####Example
+##### Example
 ```c++
 RTC.squareWave(SQWAVE_1_HZ);	//1 Hz square wave
 RTC.squareWave(SQWAVE_NONE);	//no square wave
 ```
 
-###oscStopped(bool clearOSF)
-#####Description
+### oscStopped(bool clearOSF)
+##### Description
 Returns the value of the oscillator stop flag (OSF) bit in the control/status register which indicates that the oscillator is or was stopped, and that the timekeeping data may be invalid. Optionally clears the OSF bit depending on the argument passed. If the `clearOSF` argument is omitted, the OSF bit is cleared by default. Calls to `set()` and `write()` also clear the OSF bit.
 
-#####Syntax
+##### Syntax
 `RTC.oscStopped(clearOSF);`
-#####Parameters
+##### Parameters
 **clearOSF:** an optional true or false value to indicate whether the OSF bit should be cleared (reset). If not supplied, a default value of true is used, resetting the OSF bit. *(bool)*
-#####Returns
+##### Returns
 True or false *(bool)*
-#####Example
+##### Example
 ```c++
 if ( RTC.oscStopped(false) ) {		//check the oscillator
 	//may be trouble


### PR DESCRIPTION
GitHub's Markdown interpreter was recently changed to strictly enforce the [GFM spec](https://github.github.com/gfm/). This has caused some Markdown to no longer display as originally intended.