### PR TITLE
Added TimeLib header

### DIFF
--- a/examples/SetSerial/SetSerial.ino
+++ b/examples/SetSerial/SetSerial.ino
@@ -35,6 +35,7 @@
 #include <DS3232RTC.h>        //http://github.com/JChristensen/DS3232RTC
 #include <Streaming.h>        //http://arduiniana.org/libraries/streaming/
 #include <Time.h>             //http://playground.arduino.cc/Code/Time
+#include <TimeLib.h>          //https://github.com/PaulStoffregen/Time
 #include <Wire.h>             //http://arduino.cc/en/Reference/Wire
 
 void setup(void)


### PR DESCRIPTION
The sketch does not compile without TimeLib.h by Paul Stoffregen. It throws an error at setSyncProvider(RTC.get) unless if you include TimeLib.h