### PR TITLE
Add function that returns temperature as Celsius as a float

### DIFF
--- a/src/DS3232RTC.cpp
+++ b/src/DS3232RTC.cpp
@@ -358,6 +358,14 @@ int DS3232RTC::temperature()
     return rtcTemp.i / 64;
 }
 
+// Returns the temperature in Celsius as a float
+float DS3232RTC::temperatureCelsius()
+{
+    float tempDecimal = readRTC(RTC_TEMP_LSB);
+    float tempWhole = readRTC(RTC_TEMP_MSB);
+    return tempWhole + (tempDecimal / 256.0);
+}
+
 // Decimal-to-BCD conversion
 uint8_t DS3232RTC::dec2bcd(uint8_t n)
 {

--- a/src/DS3232RTC.h
+++ b/src/DS3232RTC.h
@@ -71,6 +71,7 @@ class DS3232RTC
         void squareWave(SQWAVE_FREQS_t freq);
         bool oscStopped(bool clearOSF = false);
         int temperature();
+        float temperatureCelsius();
         static byte errCode;
 
     private:


### PR DESCRIPTION
Returning temperature as C*4 might make sense data-wise and for internal processing, as that is the precision the chip works in, however it doesn't make sense for use as a display.
And since the LSB is the decimal part and the MSB is the integral part, I think it makes sense adding that directly as a library function.
Maybe also add a "temperatureFahrenheit" lateron?