### PR TITLE
Function for enable/disable the BBSQW bit.

### DIFF
--- a/src/DS3232RTC.cpp
+++ b/src/DS3232RTC.cpp
@@ -370,6 +370,26 @@ uint8_t __attribute__ ((noinline)) DS3232RTC::bcd2dec(uint8_t n)
     return n - 6 * (n >> 4);
 }
 
+/**
+ * Sets BBSQW bit which allows to generate alarm interruptions while
+ * device is running on battery.
+ *
+ * Function accepts `on` parameter that can have values `BBSQW_ON` or
+ * `BBSQW_OFF` and returns zero, if setting up was successfull.
+ */
+byte DS3232RTC::bbsqw(bool on) {
+    byte rtc_control = readRTC(RTC_CONTROL);
+    if(on) {
+        rtc_control |= _BV(BBSQW);
+    }
+    else {
+        rtc_control &= ~_BV(BBSQW);
+    }
+    byte status = writeRTC(RTC_CONTROL, rtc_control);
+    return status;
+}
+
+
 #ifdef ARDUINO_ARCH_AVR
 DS3232RTC RTC;      // instantiate an RTC object
 #endif

--- a/src/DS3232RTC.h
+++ b/src/DS3232RTC.h
@@ -51,6 +51,9 @@ enum SQWAVE_FREQS_t {
 #define ALARM_1 1                  // constants for alarm functions
 #define ALARM_2 2
 
+#define BBSQW_ON true
+#define BBSQW_OFF false
+
 class DS3232RTC
 {
     public:
@@ -72,6 +75,7 @@ class DS3232RTC
         bool oscStopped(bool clearOSF = false);
         int16_t temperature();
         static byte errCode;
+        byte bbsqw(bool on);
 
     private:
         uint8_t dec2bcd(uint8_t n);


### PR DESCRIPTION
Function `bbsqw()` implements setting of the BBSQW bit, with help of
definitions `BBSQW_ON` and `BBSQW_OFF` as arguments.

BBSWQ bit allows us to generate alarms and alarm interruptions, while
device runs on battery.

From the data sheet: Bit 6: Battery-Backed Square-Wave Enable (BBSQW).
When set to logic 1 with INTCN = 0 and V CC < V PF , this bit enables
the square wave. When BBSQW is logic 0, the INT/SQW pin goes high
impedance when V CC < V PF .  This bit is disabled (logic 0) when
power is first applied.